### PR TITLE
adds autobuild script and update customize.sh & README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,87 @@
 ![Picsart_22-12-14_07-47-34-971](https://telegra.ph/file/72c57aba7fc39d95a1e27.png)
 
 MIUI Launcher App modified by [Kashi](https://t.me/kakashi1v1) with many features added and ui changes.
-Its installation is via Magisk on MIUI 12-13 based ROMs with Android 10 or higher.
 
-**Changelog:**
-• New user interface
-• Changes in user interface
-• Implemented more functions
-• Can choose between iOS and Default for recent tasks
-• Folder size unlocked for versions lower than MIUI 14
-• Monet enabled
-• Fixed loading screen for lots of users
-• Blur folder bug fix and rounded folder for roms below than A12
-• More ...........
+### Prerequisites
+- Device rooted by [Magisk latest stable](https://github.com/topjohnwu/Magisk/releases/latest).
+- MIUI 12-13 based ROMs with Android 10 or higher
 
-**Notes**
-• Tested on Global/Cn/Eu ROMs based on MIUI 13 - Android 12
-• Miui 14 Cn users need to install core patch lsposed and extract apk to install, Eu users can flash the module simply
-• If you use this Launcher on your custom rom don't forget to give credits for the effort
-• For issues or questions you can send a message in [Telegram](https://t.me/bootloop_discussion) group.
+### Changelog
+- New user interface
+- Changes in user interface
+- Implemented more functions
+- Can choose between iOS and Default for recent tasks
+- Folder size unlocked for versions lower than MIUI 14
+- Monet enabled
+- Fixed loading screen for lots of users
+- Blur folder bug fix and rounded folder for roms below than A12
+- More ...........
 
-### Download ###
-Download from [releases page](https://github.com/Mods-Center/Miui_Launcher_Mod/releases)
+### Notes
+- Tested on Global/Cn/Eu ROMs based on MIUI 13 - Android 12
+- Miui 14 Cn users need to install core patch lsposed and extract apk to install, Eu users can flash the module simply
+- If you use this Launcher on your custom rom don't forget to give credits for the effort
+- For issues or questions you can send a message in [Telegram](https://t.me/bootloop_discussion) group.
 
+### Download
+- Download from [releases page](https://github.com/Mods-Center/Miui_Launcher_Mod/releases)
 
-**Instructions**
-• Download zip and flash in Magisk
-• Reboot your device
-• Enjoy!
+### Instructions
+- Download zip and flash in Magisk
+- Reboot your device
+- Enjoy!
 
+## Building from source
+
+### For Ubuntu, Debian, and other Linux distributions
+- Clone the repo using git.
+```sh
+git clone --depth=1 https://github.com/Mods-Center/Miui_Launcher_Mod
+```
+- Navigate to the **Miui_Launcher_Mod** folder.
+```sh
+cd Miui_Launcher_Mod
+```
+- Run autobuild.sh.
+```sh
+bash autobuild.sh
+```
+- Use below command to update repo if you have already cloned it before.
+```sh
+git pull
+```
+
+> The required zip package install command is in the script itself. However, if you encounter any errors, you need install **zip** utility manually.
+
+### For Termux
+- Open Termux, copy & paste this command:
+```sh
+termux-setup-storage
+```
+and give Termux storage access. If you get this warning "It appears that directory '~/storage' already exists. This script is going to rebuild its structure from scratch, wiping all dangling files. The actual storage content is not going to be deleted" then just do press "y". It won't do any harm to your device.
+- Now copy & paste this command:
+```sh
+pkg upgrade || true
+pkg install -y git
+rm -rf Miui_Launcher_Mod
+git clone --depth=1 https://github.com/Mods-Center/Miui_Launcher_Mod
+cd Miui_Launcher_Mod
+bash autobuild.sh
+mv MIUI\ Launcher\ MOD* /sdcard
+echo "Your magisk module is available in Internal Storage"
+```
+- Please make sure to grant storage permissions, if Termux asks you to do so, you will get Magisk module in your internal storage.
+- Choose Offline Installer, Online Installer or Customize Installer using number keys.
+- Use [Termux From F-Droid](https://f-droid.org/en/packages/com.termux/) to perform these tasks.
+- The required zip package install command is in the script itself. However, if you encounter any errors, you can install **zip** manually. Use the following command to do so."
+```sh
+pkg install zip
+```
+- Use below command to update repo if you have already cloned it before.
+```sh
+cd Miui_Launcher_Mod
+git pull
+```
 
 ### Screenshots ###
 ![photo_2022-12-16_21-10-41](https://telegra.ph/file/171a778ecc6d9ecb0d92a.png)

--- a/autobuild.sh
+++ b/autobuild.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/bash
+
+# Check for the Distro Type
+
+# Check if pkg package manager is available
+which "pkg"
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+    # Install zip and figlet package using pkg
+    pkg install zip figlet
+fi
+
+# Check if apt package manager is available
+which "apt"
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+    # Install zip and figlet package using apt-get
+    sudo apt-get install zip figlet
+fi
+
+# Check if yum package manager is available
+which "yum"
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+    # Install zip and figlet package using yum
+    sudo yum install zip figlet
+fi
+
+# Check if dnf package manager is available
+which "dnf"
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+    # Install zip and figlet package using dnf
+    sudo dnf install zip figlet
+fi
+
+# Check if pacman package manager is available
+which "pacman"
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+    # Install zip and figlet package using pacman
+    sudo pacman -S zip figlet
+fi
+
+# Check if zypper package manager is available
+which "zypper"
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+    # Install zip and figlet package using zypper
+    sudo zypper install zip figlet
+fi
+
+# Check if the current Linux distribution is Fedora
+if [ -f /etc/fedora-release ]; then
+    # Install zip and figlet package using dnf
+    sudo dnf install zip figlet
+fi
+
+# Display "Lawnchair Magisk" in bigger fonts
+figlet "MIUI Launcher MOD"
+
+# Check if zip is installed
+if ! command -v zip >/dev/null; then
+    echo "Error: zip is not installed. Please install it manually and try again."
+    exit 1
+fi
+
+# Read version from module.prop file
+version=$(grep "version=" module.prop | cut -d "=" -f 2)
+
+# Delete already exists module zip
+rm -rf MIUI\ Launcher\ MOD*
+
+# Check if the current directory has system folder and setup.sh to verify that current directory is valid
+if [ ! -d "files" ] || [ ! -f "customize.sh" ]; then
+    echo "Error: Current directory is not valid. Make sure that you are in the right directory and try again."
+    exit 1
+fi
+
+# Make empty system folder
+mkdir system
+mkdir system/priv-app
+mkdir system/priv-app/aMiuiHome
+mkdir system/product
+mkdir system/product/overlay
+mkdir system/product/priv-app
+mkdir system/product/priv-app/aMiuiHome
+
+# Create zip file
+echo ">> Creating zip file"
+echo ""                                                                        # make the output look easier to read
+zip -r -q "MIUI Launcher MOD $version.zip" . -x .git/\* autobuild.sh README.md # Ignore specified files and folders because they are not needed for the module
+echo ""                                                                        # make the output look easier to read
+echo ">> Done! You can find the module zip file in the current directory - '$(pwd)/MIUI Launcher MOD $version.zip'"
+
+# Return back to oriinal state
+rm -rf system

--- a/customize.sh
+++ b/customize.sh
@@ -23,49 +23,49 @@ SKIPMOUNT=false
 install_files() {
     . $MODPATH/addon/install.sh
 
-ui_print " "
-ui_print " Warning: Miui 14 CN is not supported, read module post to know about installation."
-ui_print " "
-ui_print " "
-ui_print "Let's start"
-ui_print "Choose your Miui Version:"
-ui_print "  Vol+ = Miui 13 or lower"
-ui_print "  Vol- = Miui 14 Android 13 Xiaomi.eu based"
-ui_print " "
+    ui_print " "
+    ui_print " Warning: Miui 14 CN is not supported, read module post to know about installation."
+    ui_print " "
+    ui_print " "
+    ui_print "Let's start"
+    ui_print "Choose your Miui Version:"
+    ui_print "  Vol+ = Miui 13 or lower"
+    ui_print "  Vol- = Miui 14 Android 13 Xiaomi.eu based"
+    ui_print " "
 
-if chooseport; then
-    ui_print "- Miui 13 or lower selected"
-    cp -rf $MODPATH/files/launcher/MiuiHome.apk $MODPATH/system/priv-app/aMiuiHome
-else
-{
-    ui_print "- Miui 14 Eu selected"
-    cp -rf $MODPATH/files/launcher/MiuiHome.apk $MODPATH/system/product/priv-app/aMiuiHome
-}
+    if chooseport; then
+        ui_print "- Miui 13 or lower selected"
+        cp -rf $MODPATH/files/launcher/MiuiHome.apk $MODPATH/system/priv-app/aMiuiHome
+    else
+        {
+            ui_print "- Miui 14 Eu selected"
+            cp -rf $MODPATH/files/launcher/MiuiHome.apk $MODPATH/system/product/priv-app/aMiuiHome
+        }
 
-fi
+    fi
     ui_print " "
     ui_print " Is your device POCO?"
     ui_print "  Vol+ = Yes"
     ui_print "  Vol- = No"
     ui_print " "
 
-if chooseport; then
-    ui_print "- Deleting POCO Launcher and adding MiuiHome support."
-    cp -rf $MODPATH/files/poco/Framework_resoverlay.apk $MODPATH/system/product/overlay
-else
-{
-    ui_print "- Skipping..."
-}
+    if chooseport; then
+        ui_print "- Deleting POCO Launcher and adding MiuiHome support."
+        cp -rf $MODPATH/files/poco/Framework_resoverlay.apk $MODPATH/system/product/overlay
+    else
+        {
+            ui_print "- Skipping..."
+        }
 
-fi
+    fi
 
 }
 
 cleanup() {
-	rm -rf $MODPATH/addon 2>/dev/null
-	rm -rf $MODPATH/files 2>/dev/null
-	rm -f $MODPATH/install.sh 2>/dev/null
-	ui_print "- Deleting package cache files"
+    rm -rf $MODPATH/addon 2>/dev/null
+    rm -rf $MODPATH/files 2>/dev/null
+    rm -f $MODPATH/install.sh 2>/dev/null
+    ui_print "- Deleting package cache files"
     rm -rf /data/resource-cache/*
     rm -rf /data/system/package_cache/*
     rm -rf /cache/*
@@ -77,19 +77,19 @@ cleanup() {
 }
 
 run_install() {
-	ui_print " "
-	unzip -o "$ZIPFILE" -x 'META-INF/*' -d $MODPATH >&2
-	ui_print " "
-	ui_print "- Installing files"
-	install_files
-	sleep 1
-	ui_print " "
-	ui_print "- Cleaning up"
-	ui_print " "
-	cleanup
-	sleep 1
-	ui_print " "
-	ui_print "- Removing any Miui Launcher folder to avoid issues"
+    ui_print " "
+    unzip -o "$ZIPFILE" -x 'META-INF/*' -d $MODPATH >&2
+    ui_print " "
+    ui_print "- Installing files"
+    install_files
+    sleep 1
+    ui_print " "
+    ui_print "- Cleaning up"
+    ui_print " "
+    cleanup
+    sleep 1
+    ui_print " "
+    ui_print "- Removing any Miui Launcher folder to avoid issues"
 }
 
 run_install


### PR DESCRIPTION
about autobuild script: It will help to make magisk module on the fly. It make all required empty folders, detect version details from prop & add it in name of the output module zip. The autobuild script can be used on termux(f-droid version) or any other linux distro.
about README changes: I made some changes in markdown and added instructions on how to use autobuild & make the module.
about customize.sh changes: Made code look cleaner.