### PR TITLE
Fixed file permissions on customize script

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -76,6 +76,24 @@ cleanup() {
     touch /data/adb/modules/miui_launcher_mod/remove
 }
 
+set_permissions() {
+    #
+    # Credit goes to the Magisk Module Template Extended by Zackptg5
+    #
+    # https://github.com/Zackptg5/MMT-Extended/blob/master/common/functions.sh#L226
+    #
+	set_perm_recursive $MODPATH 0 0 0755 0644
+	if [ -d $MODPATH/system/vendor ]; then
+		set_perm_recursive $MODPATH/system/vendor 0 0 0755 0644 u:object_r:vendor_file:s0
+		[ -d $MODPATH/system/vendor/app ] && set_perm_recursive $MODPATH/system/vendor/app 0 0 0755 0644 u:object_r:vendor_app_file:s0
+		[ -d $MODPATH/system/vendor/etc ] && set_perm_recursive $MODPATH/system/vendor/etc 0 0 0755 0644 u:object_r:vendor_configs_file:s0
+		[ -d $MODPATH/system/vendor/overlay ] && set_perm_recursive $MODPATH/system/vendor/overlay 0 0 0755 0644 u:object_r:vendor_overlay_file:s0
+		for FILE in $(find $MODPATH/system/vendor -type f -name *".apk"); do
+			[ -f $FILE ] && chcon u:object_r:vendor_app_file:s0 $FILE
+		done
+	fi
+}
+
 run_install() {
 	ui_print " "
 	unzip -o "$ZIPFILE" -x 'META-INF/*' -d $MODPATH >&2
@@ -87,6 +105,10 @@ run_install() {
 	ui_print "- Cleaning up"
 	ui_print " "
 	cleanup
+	sleep 1
+	ui_print " "
+	ui_print "- Setting Permissions"
+	set_permissions
 	sleep 1
 	ui_print " "
 	ui_print "- Removing any Miui Launcher folder to avoid issues"

--- a/module.prop
+++ b/module.prop
@@ -3,4 +3,4 @@ name=MIUI14 Launcher Mod by Mods Center
 version=V2 Final
 versionCode=39
 author=🅺🅰🆂🅷🅸
-description=Thanks to Kevin Miranda for helping and Xposeded for iOS recent.
+description=Thanks to Kevin Miranda for helping and Xposeded for iOS recent. File permissions fixed by DodoLeDev


### PR DESCRIPTION
File permissions for APKs files have been forgotten in your installation script.
This pull request attempts to fix this problem.